### PR TITLE
Paginated collections support

### DIFF
--- a/lib/ebay_api/middlewares.rb
+++ b/lib/ebay_api/middlewares.rb
@@ -1,1 +1,2 @@
 require_relative "middlewares/json_response"
+require_relative "middlewares/paginated_collection"

--- a/lib/ebay_api/middlewares/paginated_collection.rb
+++ b/lib/ebay_api/middlewares/paginated_collection.rb
@@ -1,0 +1,34 @@
+# Parses API response as JSON
+class EbayAPI
+  class PaginatedCollection
+    class MiddlewareBuilder
+      class << self
+        def call(max_limit: 500)
+          Class.new(Middleware).tap do |middleware|
+            middleware.send(:define_method, :max_limit) { max_limit }
+          end
+        end
+      end
+    end
+
+    class Middleware
+      def initialize(app)
+        @app = app
+      end
+
+      def max_limit
+        raise NotImplementedError, <<~MSG.tr("\n", " ")
+          You can't use #{self.class} directly.
+          Use it with EbayAPI::PaginatedCollection::MiddlewareBuilder.call!
+        MSG
+      end
+
+      def call(env)
+        query = Rack::Utils.parse_nested_query(env["QUERY_STRING"])
+        query["limit"] = [query["limit"].to_i, max_limit].min if query["limit"]
+        env["QUERY_STRING"] = Rack::Utils.build_nested_query(query)
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/lib/ebay_api/paginated_collection.rb
+++ b/lib/ebay_api/paginated_collection.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+#
+class EbayAPI
+  class PaginatedCollection
+    class Request < Evil::Client::Resolver::Request
+      def initialize(schema, settings, uri:, limit: nil)
+        super(schema, settings)
+        @uri = URI(uri)
+        @limit = limit
+      end
+
+      def environment
+        super.merge!("QUERY_STRING" => paginated_query)
+      end
+
+      private
+
+      def paginated_query
+        return @uri.query unless @limit
+        q = Rack::Utils.parse_nested_query(@uri.query)
+        q["limit"] = [q["limit"]&.to_i, @limit].compact.min
+        Rack::Utils.build_nested_query(q)
+      end
+    end
+
+    include Enumerable
+
+    attr_reader :size
+
+    def initialize(handler, response, key)
+      @schema             = handler.instance_variable_get(:@__schema__)
+      @settings           = handler.instance_variable_get(:@__settings__)
+      @expected_status    = handler.instance_variable_get(:@__keys__).last
+      @key                = key
+      @initial_collection = handle_response(*response)
+      @records_left       = @settings.limit
+      @initial_next       = @next
+    end
+
+    def each
+      return to_enum unless block_given?
+      @collection = @initial_collection
+      @next       = @initial_next
+      loop do
+        @collection.each { |element| yield(element) }
+        raise StopIteration if all_records_loaded?
+        load_next!
+      end
+    end
+
+    private
+
+    def all_records_loaded?
+      return true unless @next
+      @records_left && (@records_left -= @collection.size).zero?
+    end
+
+    def load_next!
+      request = Request.call @schema, @settings,
+                             uri: @next, limit: @records_left
+      middleware = Evil::Client::Resolver::Middleware.call(@schema, @settings)
+      connection = @schema.client.connection
+      stack      = middleware.inject(connection) { |app, layer| layer.new app }
+      handle_response(*stack.call(request))
+    end
+
+    def handle_response(status, _headers, (data, *))
+      raise EbayAPI::Error unless status == @expected_status
+      @next = data["next"]
+      @size = data["total"]
+      @collection = data[@key]
+    end
+  end
+end

--- a/spec/paginated_collection_spec.rb
+++ b/spec/paginated_collection_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "ebay_api/paginated_collection"
+
+RSpec.describe EbayAPI::PaginatedCollection do
+  let!(:operation) do
+    class EbayAPI
+      operation :test_paginated_operation do
+        http_method :get
+        path "sell/marketing/v1/ad_campaign"
+
+        option :limit,  optional: true
+        option :offset, optional: true
+
+        query { { limit: limit, offset: offset }.compact }
+
+        middleware { PaginatedCollection::MiddlewareBuilder.call(max_limit: 2) }
+
+        response(200) do |*response|
+          EbayAPI::PaginatedCollection.new(self, response, "campaigns")
+        end
+      end
+    end
+  end
+
+  let(:client)   { EbayAPI.new(settings) }
+  let(:settings) { yaml_fixture_file(settings_file) }
+  let(:settings_file) { "settings.valid.yml" }
+
+  # Mimic real paginated API
+  let!(:request) do
+    uri_template = Addressable::Template.new(
+      "https://api.ebay.com/sell/marketing/v1/ad_campaign{?limit,offset}"
+    )
+    stub_request(:get, uri_template).to_return do |request|
+      uri = Addressable::URI.parse(request.uri)
+      offset = uri.query_values&.fetch("offset", nil).to_i || 0
+      limit  = uri.query_values&.fetch("limit", nil)&.to_i || 2
+      total  = 5
+      this_uri = uri.dup.tap do |u|
+        new_params = { "offset" => offset, "limit" => limit }
+        u.query_values = (uri.query_values || {}).merge(new_params)
+      end
+      next_uri = this_uri.dup.tap do |u|
+        u.query_values = this_uri.query_values.merge("offset" => offset + limit)
+      end
+      on_this_page = offset + limit <= total ? limit : total - offset
+      response = {
+        href: this_uri,
+        total: total,
+        next: (next_uri if offset + limit < total),
+        campaigns: Array.new(on_this_page) { |i| { id: offset + i } }
+      }
+      { body: response.to_json }
+    end
+  end
+
+  let(:params) { {} }
+
+  subject { client.test_paginated_operation(**params) }
+
+  it "retrieves all pages" do
+    expect(subject.to_a).to eq(Array.new(5) { |i| { "id" => i } })
+    expect(request).to have_been_requested.times(3)
+  end
+
+  it "retrieves all pages lazily" do
+    e = subject.lazy
+    expect(e.next).to eq({ "id" => 0 })
+    expect(e.next).to eq({ "id" => 1 })
+    expect(request).to have_been_requested.once
+    expect(e.next).to eq({ "id" => 2 })
+    expect(e.next).to eq({ "id" => 3 })
+    expect(request).to have_been_requested.twice
+    expect(e.next).to eq({ "id" => 4 })
+    expect { e.next }.to raise_exception(StopIteration)
+    expect(request).to have_been_requested.times 3
+  end
+
+  context "with custom offset" do
+    let(:params) { { offset: 3 } }
+
+    it "retrieves pages only with this offset" do
+      e = subject.lazy
+      expect(e.next).to eq({ "id" => 3 })
+      expect(e.next).to eq({ "id" => 4 })
+      expect { e.next }.to raise_exception(StopIteration)
+      expect(request).to have_been_requested.once
+    end
+  end
+
+  context "with custom limit" do
+    let(:params) { { limit: 3 } }
+
+    it "retrieves pages only specified number of records" do
+      e = subject.lazy
+      expect(e.next).to eq({ "id" => 0 })
+      expect(e.next).to eq({ "id" => 1 })
+      expect(request).to have_been_requested.once
+      expect(e.next).to eq({ "id" => 2 })
+      expect { e.next }.to raise_exception(StopIteration)
+      expect(request).to have_been_requested.twice
+    end
+  end
+end


### PR DESCRIPTION
Here is __very__ dirty attempt to add support for handling of paginated index actions.

The main problem is that we need to repeat request for the same operation with all options (HTTP method, tokens and etc), but only to another URL. I have hacked around `evil-client` internals to get things working, but now I need to think how to implement it cleaner.

Usage:

```ruby
operation :list do
  http_method :get

  option :limit,  optional: true
  option :offset, optional: true

  query { { limit: limit, offset: offset }.compact }

  response(200) do |*response|
    EbayAPI::PaginatedCollection.new(self, response, "campaigns")
  end
end
```
And then:

```ruby
result = client.list

# Will issue requests to retrieve all records
result.each { |campaign| do_stuff }

# Will issue only requests needed to get required campaigns
# (no additional requests if all of them are on the first page)
result.lazy.map { |campaign| campaign["campaignId"] }.take(5).to_a
```