### PR TITLE
commerce/taxonomy boilerplate and two operations

### DIFF
--- a/lib/ebay_api/operations.rb
+++ b/lib/ebay_api/operations.rb
@@ -1,1 +1,2 @@
+require_relative "operations/commerce"
 require_relative "operations/sell"

--- a/lib/ebay_api/operations/commerce.rb
+++ b/lib/ebay_api/operations/commerce.rb
@@ -1,0 +1,10 @@
+#
+# Commerce API
+#
+class EbayAPI
+  scope :commerce do
+    path "commerce"
+
+    require_relative "commerce/taxonomy"
+  end
+end

--- a/lib/ebay_api/operations/commerce/taxonomy.rb
+++ b/lib/ebay_api/operations/commerce/taxonomy.rb
@@ -1,0 +1,12 @@
+#
+# Commerce Taxonomy API
+#
+class EbayAPI
+  scope :commerce do
+    scope :taxonomy do
+      path { "taxonomy/v#{EbayAPI::COMMERCE_TAXONOMY_VERSION[/^[^\.]+/]}" }
+      require_relative "taxonomy/category_tree"
+      require_relative "taxonomy/get_default_category_tree_id"
+    end
+  end
+end

--- a/lib/ebay_api/operations/commerce/taxonomy/category_tree.rb
+++ b/lib/ebay_api/operations/commerce/taxonomy/category_tree.rb
@@ -1,0 +1,14 @@
+require_relative "category_tree/get_item_aspects_for_category"
+
+#
+# Category tree-related operations of the taxonomy API
+#
+class EbayAPI
+  scope :commerce do
+    scope :taxonomy do
+      scope :category_tree do
+        path "category_tree"
+      end
+    end
+  end
+end

--- a/lib/ebay_api/operations/commerce/taxonomy/category_tree/get_item_aspects_for_category.rb
+++ b/lib/ebay_api/operations/commerce/taxonomy/category_tree/get_item_aspects_for_category.rb
@@ -1,0 +1,16 @@
+class EbayAPI
+  scope :commerce do
+    scope :taxonomy do
+      scope :category_tree do
+        operation :get_item_aspects_for_category do
+          http_method :get
+          option :category_tree_id
+          option :category_id
+          path { "#{category_tree_id}/get_item_aspects_for_category" }
+          query { { category_id: category_id } }
+          response(200) { |_, _, (data, *)| data }
+        end
+      end
+    end
+  end
+end

--- a/lib/ebay_api/operations/commerce/taxonomy/get_default_category_tree_id.rb
+++ b/lib/ebay_api/operations/commerce/taxonomy/get_default_category_tree_id.rb
@@ -1,0 +1,13 @@
+class EbayAPI
+  scope :commerce do
+    scope :taxonomy do
+      operation :get_default_category_tree_id do
+        http_method :get
+        option :marketplace_id
+        path { "get_default_category_tree_id" }
+        query { { marketplace_id: marketplace_id } }
+        response(200) { |_, _, (data, *)| data }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello again guys! I've added two operations from the commerce/taxonomy beta API. There is no error handling, I didn't want to spend time on polishing this as the API itself is still in beta.