### PR TITLE
Payment policy operations and fixes

### DIFF
--- a/ebay_api.gemspec
+++ b/ebay_api.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name     = "ebay_api"
-  gem.version  = "0.0.5"
+  gem.version  = "0.0.6"
   gem.author   = "Andrew Kozin (nepalez)"
   gem.email    = "andrew.kozin@gmail.com"
   gem.homepage = "https://github.com/nepalez/sms_aero"

--- a/ebay_api.gemspec
+++ b/ebay_api.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec-its", "~> 1.2"
   gem.add_development_dependency "rubocop", "~> 0.49"
   gem.add_development_dependency "timecop", "~> 0.9"
-  gem.add_development_dependency "webmock", "~> 2.1"
+  gem.add_development_dependency "webmock", "~> 3.14"
   gem.add_development_dependency "httplog"
 end

--- a/lib/ebay_api.rb
+++ b/lib/ebay_api.rb
@@ -72,12 +72,15 @@ class EbayAPI < Evil::Client
   # https://developer.ebay.com/api-docs/static/handling-error-messages.html
   response(400, 401, 409) do |_, _, (data, *)|
     data = data.to_h
-    case (code = data.dig("errors", 0, "errorId"))
+    error = data.dig("errors", 0) || {}
+    code = error["errorId"]
+    message = error["longMessage"] || error["message"]
+
+    case code
     when 1001
-      message = data.dig("errors", 0, "longMessage")
       raise InvalidAccessToken.new(code: code), message
     else
-      raise Error.new(code: code, data: data), data.dig("errors", 0, "message")
+      raise Error.new(code: code, data: data), message
     end
   end
 

--- a/lib/ebay_api/models/bid_percentage.rb
+++ b/lib/ebay_api/models/bid_percentage.rb
@@ -18,7 +18,5 @@ class EbayAPI
     def to_s
       @value
     end
-    alias to_h to_s
-    alias to_hash to_s
   end
 end

--- a/lib/ebay_api/operations/sell/account.rb
+++ b/lib/ebay_api/operations/sell/account.rb
@@ -10,6 +10,7 @@ class EbayAPI
       require_relative "account/program"
       require_relative "account/fulfillment_policy"
       require_relative "account/return_policy"
+      require_relative "account/payment_policy"
       require_relative "account/payments_program"
     end
   end

--- a/lib/ebay_api/operations/sell/account/fulfillment_policy/get_by_name.rb
+++ b/lib/ebay_api/operations/sell/account/fulfillment_policy/get_by_name.rb
@@ -7,7 +7,7 @@ class EbayAPI
           option :site, Site
           option :name, proc(&:to_s)
 
-          path  { "/" }
+          path  { "/get_by_policy_name" }
           query { { marketplace_id: site.key, name: name } }
           http_method :get
         end

--- a/lib/ebay_api/operations/sell/account/payment_policy.rb
+++ b/lib/ebay_api/operations/sell/account/payment_policy.rb
@@ -1,0 +1,16 @@
+class EbayAPI
+  scope :sell do
+    scope :account do
+      scope :payment_policy do
+        path { "payment_policy" }
+      end
+    end
+  end
+end
+
+require_relative "payment_policy/delete"
+require_relative "payment_policy/get"
+require_relative "payment_policy/get_by_name"
+require_relative "payment_policy/index"
+require_relative "payment_policy/create"
+require_relative "payment_policy/update"

--- a/lib/ebay_api/operations/sell/account/payment_policy/create.rb
+++ b/lib/ebay_api/operations/sell/account/payment_policy/create.rb
@@ -1,0 +1,17 @@
+class EbayAPI
+  scope :sell do
+    scope :account do
+      scope :payment_policy do
+        # @see https://developer.ebay.com/api-docs/sell/account/resources/payment_policy/methods/createPaymentPolicy
+        operation :create do
+          option :site, Site
+          option :data, proc(&:to_h) # TODO: add model to validate input
+
+          path { "/" }
+          http_method :post
+          body { data.merge("marketplaceId" => site.key) }
+        end
+      end
+    end
+  end
+end

--- a/lib/ebay_api/operations/sell/account/payment_policy/delete.rb
+++ b/lib/ebay_api/operations/sell/account/payment_policy/delete.rb
@@ -1,0 +1,15 @@
+class EbayAPI
+  scope :sell do
+    scope :account do
+      scope :payment_policy do
+        # @see https://developer.ebay.com/api-docs/sell/account/resources/payment_policy/methods/deletePaymentPolicy
+        operation :delete do
+          option :id, proc(&:to_s)
+
+          path { id }
+          http_method :delete
+        end
+      end
+    end
+  end
+end

--- a/lib/ebay_api/operations/sell/account/payment_policy/get.rb
+++ b/lib/ebay_api/operations/sell/account/payment_policy/get.rb
@@ -1,0 +1,15 @@
+class EbayAPI
+  scope :sell do
+    scope :account do
+      scope :payment_policy do
+        # @see https://developer.ebay.com/api-docs/sell/account/resources/payment_policy/methods/getPaymentPolicy
+        operation :get do
+          option :id, proc(&:to_s)
+
+          path { id }
+          http_method :get
+        end
+      end
+    end
+  end
+end

--- a/lib/ebay_api/operations/sell/account/payment_policy/get_by_name.rb
+++ b/lib/ebay_api/operations/sell/account/payment_policy/get_by_name.rb
@@ -1,0 +1,17 @@
+class EbayAPI
+  scope :sell do
+    scope :account do
+      scope :payment_policy do
+        # @see https://developer.ebay.com/api-docs/sell/account/resources/payment_policy/methods/getPaymentPolicyByName
+        operation :get_by_name do
+          option :site, Site
+          option :name, proc(&:to_s)
+
+          path  { "/get_by_policy_name" }
+          query { { marketplace_id: site.key, name: name } }
+          http_method :get
+        end
+      end
+    end
+  end
+end

--- a/lib/ebay_api/operations/sell/account/payment_policy/index.rb
+++ b/lib/ebay_api/operations/sell/account/payment_policy/index.rb
@@ -1,0 +1,16 @@
+class EbayAPI
+  scope :sell do
+    scope :account do
+      scope :payment_policy do
+        # @see https://developer.ebay.com/api-docs/sell/account/resources/payment_policy/methods/getPaymentPolicies
+        operation :index do
+          option :site, Site
+
+          path  { "/" }
+          query { { marketplace_id: site.key } }
+          http_method :get
+        end
+      end
+    end
+  end
+end

--- a/lib/ebay_api/operations/sell/account/payment_policy/update.rb
+++ b/lib/ebay_api/operations/sell/account/payment_policy/update.rb
@@ -1,0 +1,18 @@
+class EbayAPI
+  scope :sell do
+    scope :account do
+      scope :payment_policy do
+        # @see https://developer.ebay.com/api-docs/sell/account/resources/payment_policy/methods/updatePaymentPolicy
+        operation :update do
+          option :id,   proc(&:to_s)
+          option :site, Site
+          option :data, proc(&:to_h) # TODO: add model to validate input
+
+          path { id }
+          http_method :put
+          body { data.merge("marketplaceId" => site.key) }
+        end
+      end
+    end
+  end
+end

--- a/lib/ebay_api/operations/sell/account/return_policy/get_by_name.rb
+++ b/lib/ebay_api/operations/sell/account/return_policy/get_by_name.rb
@@ -7,7 +7,7 @@ class EbayAPI
           option :site, Site
           option :name, proc(&:to_s)
 
-          path  { "/" }
+          path  { "/get_by_policy_name" }
           query { { marketplace_id: site.key, name: name } }
           http_method :get
         end

--- a/spec/fixtures/sell/account/payment_policy/create/request.yml
+++ b/spec/fixtures/sell/account/payment_policy/create/request.yml
@@ -1,0 +1,7 @@
+---
+immediatePay: false
+categoryTypes:
+- name: ALL_EXCLUDING_MOTORS_VEHICLES
+marketplaceId: EBAY_US
+paymentMethods: []
+name: Managed Payments

--- a/spec/fixtures/sell/account/payment_policy/create/success
+++ b/spec/fixtures/sell/account/payment_policy/create/success
@@ -1,0 +1,5 @@
+HTTP/1.1 201 Created
+Content-Length: 216
+Content-Type: application/json
+
+{"name":"Managed Payments","marketplaceId":"EBAY_US","categoryTypes":[{"name":"ALL_EXCLUDING_MOTORS_VEHICLES","default":false}],"paymentMethods":[],"immediatePay":false,"paymentPolicyId":"185091636024","warnings":[]}

--- a/spec/fixtures/sell/account/payment_policy/create/success.yml
+++ b/spec/fixtures/sell/account/payment_policy/create/success.yml
@@ -1,0 +1,10 @@
+---
+name: Managed Payments
+marketplaceId: EBAY_US
+categoryTypes:
+- name: ALL_EXCLUDING_MOTORS_VEHICLES
+  default: false
+paymentMethods: []
+immediatePay: false
+paymentPolicyId: "185091636024"
+warnings: []

--- a/spec/fixtures/sell/account/payment_policy/get/success
+++ b/spec/fixtures/sell/account/payment_policy/get/success
@@ -1,0 +1,5 @@
+HTTP/1.1 200 OK
+Content-Length: 232
+Content-Type: application/json
+
+{"name":"Managed Payments","description":"eBay Payments","marketplaceId":"EBAY_US","categoryTypes":[{"name":"ALL_EXCLUDING_MOTORS_VEHICLES","default":false}],"paymentMethods":[],"immediatePay":false,"paymentPolicyId":"184528067024"}

--- a/spec/fixtures/sell/account/payment_policy/get/success.yml
+++ b/spec/fixtures/sell/account/payment_policy/get/success.yml
@@ -1,0 +1,10 @@
+---
+name: Managed Payments
+description: eBay Payments
+marketplaceId: EBAY_US
+categoryTypes:
+- name: ALL_EXCLUDING_MOTORS_VEHICLES
+  default: false
+paymentMethods: []
+immediatePay: false
+paymentPolicyId: "184528067024"

--- a/spec/fixtures/sell/account/payment_policy/get_by_name/success
+++ b/spec/fixtures/sell/account/payment_policy/get_by_name/success
@@ -1,0 +1,5 @@
+HTTP/1.1 200 OK
+Content-Length: 202
+Content-Type: application/json
+
+{"name":"Managed Payments","marketplaceId":"EBAY_US","categoryTypes":[{"name":"ALL_EXCLUDING_MOTORS_VEHICLES","default":false}],"paymentMethods":[],"immediatePay":false,"paymentPolicyId":"185091636024"}

--- a/spec/fixtures/sell/account/payment_policy/get_by_name/success.yml
+++ b/spec/fixtures/sell/account/payment_policy/get_by_name/success.yml
@@ -1,0 +1,9 @@
+---
+name: Managed Payments
+marketplaceId: EBAY_US
+categoryTypes:
+- name: ALL_EXCLUDING_MOTORS_VEHICLES
+  default: false
+paymentMethods: []
+immediatePay: false
+paymentPolicyId: "185091636024"

--- a/spec/fixtures/sell/account/payment_policy/index/success
+++ b/spec/fixtures/sell/account/payment_policy/index/success
@@ -1,0 +1,5 @@
+HTTP/1.1 200 OK
+Content-Length: 2010
+Content-Type: application/json
+
+{"total":3,"paymentPolicies":[{"name":"PayPal#1","description":"PayPal, userpaypal1@gmail.com","marketplaceId":"EBAY_US","categoryTypes":[{"name":"ALL_EXCLUDING_MOTORS_VEHICLES","default":true}],"paymentMethods":[{"paymentMethodType":"PAYPAL","recipientAccountReference":{"referenceType":"PAYPAL_EMAIL","referenceId":"userpaypal1@gmail.com"}}],"immediatePay":false,"paymentPolicyId":"103323093024"},{"name":"PayPal#2","description":"PayPal, userpaypal2@gmail.com","marketplaceId":"EBAY_US","categoryTypes":[{"name":"ALL_EXCLUDING_MOTORS_VEHICLES","default":false}],"paymentMethods":[{"paymentMethodType":"PAYPAL","recipientAccountReference":{"referenceType":"PAYPAL_EMAIL","referenceId":"userpaypal2@gmail.com"}}],"immediatePay":false,"paymentPolicyId":"117938331024"},{"name":"Managed Payments","marketplaceId":"EBAY_US","categoryTypes":[{"name":"ALL_EXCLUDING_MOTORS_VEHICLES","default":false}],"paymentMethods":[],"immediatePay":false,"paymentPolicyId":"185091636024"}]}

--- a/spec/fixtures/sell/account/payment_policy/index/success.yml
+++ b/spec/fixtures/sell/account/payment_policy/index/success.yml
@@ -1,0 +1,36 @@
+total: 3
+paymentPolicies:
+- name: PayPal#1
+  description: PayPal, userpaypal1@gmail.com
+  marketplaceId: EBAY_US
+  categoryTypes:
+  - name: ALL_EXCLUDING_MOTORS_VEHICLES
+    default: true
+  paymentMethods:
+  - paymentMethodType: PAYPAL
+    recipientAccountReference:
+      referenceType: PAYPAL_EMAIL
+      referenceId: userpaypal1@gmail.com
+  immediatePay: false
+  paymentPolicyId: "103323093024"
+- name: PayPal#2
+  description: PayPal, userpaypal2@gmail.com
+  marketplaceId: EBAY_US
+  categoryTypes:
+  - name: ALL_EXCLUDING_MOTORS_VEHICLES
+    default: false
+  paymentMethods:
+  - paymentMethodType: PAYPAL
+    recipientAccountReference:
+      referenceType: PAYPAL_EMAIL
+      referenceId: userpaypal2@gmail.com
+  immediatePay: false
+  paymentPolicyId: "117938331024"
+- name: Managed Payments
+  marketplaceId: EBAY_US
+  categoryTypes:
+  - name: ALL_EXCLUDING_MOTORS_VEHICLES
+    default: false
+  paymentMethods: []
+  immediatePay: false
+  paymentPolicyId: "185091636024"

--- a/spec/fixtures/sell/account/payment_policy/update/request.yml
+++ b/spec/fixtures/sell/account/payment_policy/update/request.yml
@@ -1,0 +1,7 @@
+---
+immediatePay: false
+categoryTypes:
+- name: ALL_EXCLUDING_MOTORS_VEHICLES
+marketplaceId: EBAY_US
+paymentMethods: []
+name: Managed Payments

--- a/spec/fixtures/sell/account/payment_policy/update/success
+++ b/spec/fixtures/sell/account/payment_policy/update/success
@@ -1,0 +1,5 @@
+HTTP/1.1 200 OK
+Content-Length: 216
+Content-Type: application/json
+
+{"name":"Managed Payments","marketplaceId":"EBAY_US","categoryTypes":[{"name":"ALL_EXCLUDING_MOTORS_VEHICLES","default":false}],"paymentMethods":[],"immediatePay":false,"paymentPolicyId":"184528067024","warnings":[]}

--- a/spec/fixtures/sell/account/payment_policy/update/success.yml
+++ b/spec/fixtures/sell/account/payment_policy/update/success.yml
@@ -1,0 +1,10 @@
+---
+name: Managed Payments
+marketplaceId: EBAY_US
+categoryTypes:
+- name: ALL_EXCLUDING_MOTORS_VEHICLES
+  default: false
+paymentMethods: []
+immediatePay: false
+paymentPolicyId: "184528067024"
+warnings: []

--- a/spec/operations/sell/account/fulfillment_policy/get_by_name_spec.rb
+++ b/spec/operations/sell/account/fulfillment_policy/get_by_name_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe EbayAPI, ".sell.account.fulfillment_policy.get_by_name" do
   let(:settings) { yaml_fixture_file("settings.valid.yml") }
   let(:version)  { "1.2.0" }
   let(:url) do
-    "https://api.ebay.com/sell/account/v1/fulfillment_policy/" \
+    "https://api.ebay.com/sell/account/v1/fulfillment_policy/get_by_policy_name" \
       "?marketplace_id=EBAY_US&name=postcards"
   end
 

--- a/spec/operations/sell/account/fulfillment_policy/index_spec.rb
+++ b/spec/operations/sell/account/fulfillment_policy/index_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe EbayAPI, ".sell.account.fulfillment_policy.index" do
   end
 
   before  { stub_request(:get, url).to_return(response) }
-  subject { scope.index id: "5733588000" }
+  subject { scope.index }
 
   context "success" do
     let(:response) do

--- a/spec/operations/sell/account/payment_policy/create_spec.rb
+++ b/spec/operations/sell/account/payment_policy/create_spec.rb
@@ -1,5 +1,3 @@
-HashDiff = Hashdiff
-
 RSpec.describe EbayAPI, ".sell.account.payment_policy.create" do
   let(:client)   { described_class.new(settings) }
   let(:scope)    { client.sell.account(version: version).payment_policy }

--- a/spec/operations/sell/account/payment_policy/create_spec.rb
+++ b/spec/operations/sell/account/payment_policy/create_spec.rb
@@ -1,0 +1,42 @@
+HashDiff = Hashdiff
+
+RSpec.describe EbayAPI, ".sell.account.payment_policy.create" do
+  let(:client)   { described_class.new(settings) }
+  let(:scope)    { client.sell.account(version: version).payment_policy }
+  let(:settings) { yaml_fixture_file("settings.valid.yml") }
+  let(:version)  { "1.2.0" }
+
+  let(:url) do
+    "https://api.ebay.com/sell/account/v1/payment_policy/"
+  end
+
+  let(:payload) do
+    yaml_fixture_file "sell/account/payment_policy/create/request.yml"
+  end
+
+  let(:data) do
+    payload.reject { |key| key == "marketplaceId" }
+  end
+
+  before  { stub_request(:post, url).with(body: payload).to_return(response) }
+  subject { scope.create site: 0, data: data }
+
+  context "success" do
+    let(:response) do
+      open_fixture_file "sell/account/payment_policy/create/success"
+    end
+
+    let(:policy) do
+      yaml_fixture_file "sell/account/payment_policy/create/success.yml"
+    end
+
+    it "sends a request" do
+      subject
+      expect(a_request(:post, url)).to have_been_made
+    end
+
+    it "returns the policy" do
+      expect(subject).to eq policy
+    end
+  end
+end

--- a/spec/operations/sell/account/payment_policy/delete_spec.rb
+++ b/spec/operations/sell/account/payment_policy/delete_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe EbayAPI, ".sell.account.payment_policy.delete" do
+  let(:url) { "https://api.ebay.com/sell/account/v1/payment_policy/184528067024" }
+  let(:client)   { described_class.new(settings) }
+  let(:scope)    { client.sell.account(version: version).payment_policy }
+  let(:settings) { yaml_fixture_file("settings.valid.yml") }
+  let(:version)  { "1.2.0" }
+
+  before  { stub_request(:delete, url).to_return(status: 204) }
+  subject { scope.delete id: "184528067024" }
+
+  context "success" do
+    it "sends a request" do
+      subject
+      expect(a_request(:delete, url)).to have_been_made
+    end
+
+    it "returns true" do
+      expect(subject).to eq true
+    end
+  end
+end

--- a/spec/operations/sell/account/payment_policy/get_by_name_spec.rb
+++ b/spec/operations/sell/account/payment_policy/get_by_name_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe EbayAPI, ".sell.account.payment_policy.get_by_name" do
+  let(:client)   { described_class.new(settings) }
+  let(:scope)    { client.sell.account(version: version).payment_policy }
+  let(:settings) { yaml_fixture_file("settings.valid.yml") }
+  let(:version)  { "1.2.0" }
+  let(:url) do
+    "https://api.ebay.com/sell/account/v1/payment_policy/get_by_policy_name" \
+      "?marketplace_id=EBAY_US&name=Managed%20Payments"
+  end
+
+  before  { stub_request(:get, url).to_return(response) }
+  subject { scope.get_by_name site: 0, name: "Managed Payments" }
+
+  context "success" do
+    let(:response) do
+      open_fixture_file "sell/account/payment_policy/get_by_name/success"
+    end
+
+    let(:policy) do
+      yaml_fixture_file \
+        "sell/account/payment_policy/get_by_name/success.yml"
+    end
+
+    it "sends a request" do
+      subject
+      expect(a_request(:get, url)).to have_been_made
+    end
+
+    it "returns the policy" do
+      expect(subject).to eq policy
+    end
+  end
+end

--- a/spec/operations/sell/account/payment_policy/get_spec.rb
+++ b/spec/operations/sell/account/payment_policy/get_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe EbayAPI, ".sell.account.payment_policy.get" do
+  let(:client)   { described_class.new(settings) }
+  let(:scope)    { client.sell.account(version: version).payment_policy }
+  let(:settings) { yaml_fixture_file("settings.valid.yml") }
+  let(:version)  { "1.2.0" }
+  let(:url) do
+    "https://api.ebay.com/sell/account/v1/payment_policy/184528067024"
+  end
+
+  before  { stub_request(:get, url).to_return(response) }
+  subject { scope.get id: "184528067024" }
+
+  context "success" do
+    let(:response) do
+      open_fixture_file "sell/account/payment_policy/get/success"
+    end
+
+    let(:policy) do
+      yaml_fixture_file "sell/account/payment_policy/get/success.yml"
+    end
+
+    it "sends a request" do
+      subject
+      expect(a_request(:get, url)).to have_been_made
+    end
+
+    it "returns the policy" do
+      expect(subject).to eq policy
+    end
+  end
+end

--- a/spec/operations/sell/account/payment_policy/index_spec.rb
+++ b/spec/operations/sell/account/payment_policy/index_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe EbayAPI, ".sell.account.payment_policy.index" do
+  let(:client)   { described_class.new(settings) }
+  let(:scope)    { client.sell.account(version: version).payment_policy }
+  let(:settings) { yaml_fixture_file("settings.valid.yml") }
+  let(:version)  { "1.2.0" }
+  let(:url) do
+    "https://api.ebay.com/sell/account/v1/payment_policy/" \
+      "?marketplace_id=EBAY_US"
+  end
+
+  before  { stub_request(:get, url).to_return(response) }
+  subject { scope.index }
+
+  context "success" do
+    let(:response) do
+      open_fixture_file "sell/account/payment_policy/get/success"
+    end
+
+    let(:policy) do
+      yaml_fixture_file "sell/account/payment_policy/get/success.yml"
+    end
+
+    it "sends a request" do
+      subject
+      expect(a_request(:get, url)).to have_been_made
+    end
+
+    it "returns the policy" do
+      expect(subject).to eq policy
+    end
+  end
+end

--- a/spec/operations/sell/account/payment_policy/update_spec.rb
+++ b/spec/operations/sell/account/payment_policy/update_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe EbayAPI, ".sell.account.payment_policy.update" do
+  let(:client)   { described_class.new(settings) }
+  let(:scope)    { client.sell.account(version: version).payment_policy }
+  let(:settings) { yaml_fixture_file("settings.valid.yml") }
+  let(:version)  { "1.2.0" }
+
+  let(:url) do
+    "https://api.ebay.com/sell/account/v1/payment_policy/184528067024"
+  end
+
+  let(:payload) do
+    yaml_fixture_file "sell/account/payment_policy/update/request.yml"
+  end
+
+  let(:data) do
+    payload.reject { |key| key == "marketplaceId" }
+  end
+
+  before  { stub_request(:put, url).to_return(response) }
+  subject { scope.update id: "184528067024", site: 0, data: data }
+
+  context "success" do
+    let(:response) do
+      open_fixture_file "sell/account/payment_policy/update/success"
+    end
+
+    let(:policy) do
+      yaml_fixture_file "sell/account/payment_policy/update/success.yml"
+    end
+
+    it "sends a request" do
+      subject
+      expect(a_request(:put, url)).to have_been_made
+    end
+
+    it "returns the policy" do
+      expect(subject).to eq policy
+    end
+  end
+end

--- a/spec/operations/sell/account/return_policy/get_by_name_spec.rb
+++ b/spec/operations/sell/account/return_policy/get_by_name_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe EbayAPI, ".sell.account.return_policy.get_by_name" do
   let(:settings) { yaml_fixture_file("settings.valid.yml") }
   let(:version)  { "1.2.0" }
   let(:url) do
-    "https://api.ebay.com/sell/account/v1/return_policy/" \
+    "https://api.ebay.com/sell/account/v1/return_policy/get_by_policy_name" \
       "?marketplace_id=EBAY_US&name=postcards"
   end
 

--- a/spec/operations/sell/account/return_policy/index_spec.rb
+++ b/spec/operations/sell/account/return_policy/index_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe EbayAPI, ".sell.account.return_policy.index" do
   end
 
   before  { stub_request(:get, url).to_return(response) }
-  subject { scope.index id: "5733588000" }
+  subject { scope.index }
 
   context "success" do
     let(:response) do


### PR DESCRIPTION
This PR:
* Adds payment policy operations (with tests);
* Fixes fulfillment and return policy `get_by_name` operation paths;
* Fixes a problem when `longMessage` was ignored in case of some 4xx errors;
* Fixes broken tests.